### PR TITLE
Update toolbox references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Zephyr examples for an Alif Semiconductor DK-E7 board. The debug launch.json fil
    ``` 
 3. Make sure to add the executable `west.exe` into the **PATH** environment variable.
 
-4. Manually download and [install](https://open-cmsis-pack.github.io/cmsis-toolbox/installation/#manual-setup) the experimental cmsis-toolbox from the following release assets:
-   > https://github.com/brondani/cmsis-toolbox/releases/tag/2.12.0-dev1
+4. Manually download and [install](https://open-cmsis-pack.github.io/cmsis-toolbox/installation/#manual-setup) the latest cmsis-toolbox from the nightly build artifacts:
+   > https://github.com/Open-CMSIS-Pack/cmsis-toolbox/actions/workflows/nightly.yml
 
 More details can be found in [Zephyr Getting Started Guide](https://docs.zephyrproject.org/latest/develop/getting_started/index.html).
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -11,7 +11,6 @@
 		"arm:tools/kitware/cmake": "^3.31.5",
 		"arm:tools/ninja-build/ninja": "^1.12.1",
 		"arm:compilers/arm/arm-none-eabi-gcc": "^14.3.1",
-		"arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.11.0",
 		"arm:tools/arm/mdk-toolbox": "^1.1.0"
 	}
 }


### PR DESCRIPTION
Now that the west support was merged into all main branches, the nightly toolbox artifacts can be referenced instead of forked branch releases.
- Update README accordingly.
- Remove older toolbox fixed version from vcpkg-configuration.json